### PR TITLE
Added new functionality: `--extra-file-info`

### DIFF
--- a/indextools/pds4_create_xml_index.py
+++ b/indextools/pds4_create_xml_index.py
@@ -172,35 +172,34 @@ def write_results_to_csv(results_list, args, output_csv_path):
 
         row = {
             'LID': lid,
-            'pds:filepath': result_dict['pds:filepath'],
-            'pds:filename': result_dict['pds:filename'],
-            'pds:bundle_lid': bundle_lid,
-            'pds:bundle': bundle
+            'filepath': result_dict['filepath'],
+            'filename': result_dict['filename'],
+            'bundle_lid': bundle_lid,
+            'bundle': bundle
         }
         row.update(result_dict['Results'])
         rows.append(row)
 
     df = pd.DataFrame(rows)
 
-    # Reorder columns to have logical_identifier, FileName, FilePath, pds:bundle_lid, and pds:bundle
     columns_order = (['LID',
-                      'pds:filename',
-                      'pds:filepath',
-                      'pds:bundle_lid',
-                      'pds:bundle'] + [col for col in df.columns if col not in
+                      'filename',
+                      'filepath',
+                      'bundle_lid',
+                      'bundle'] + [col for col in df.columns if col not in
                                        ['LID',
-                                        'pds:filename',
-                                        'pds:filepath',
-                                        'pds:bundle_lid',
-                                        'pds:bundle']])
+                                        'filename',
+                                        'filepath',
+                                        'bundle_lid',
+                                        'bundle']])
 
     df = df[columns_order]
 
     if 'LID' in df.columns:
         df = df.drop(columns=['LID'])
     if args.elements_file:
-        df = df.drop(columns=['pds:filename', 'pds:filepath',
-                              'pds:bundle_lid', 'pds:bundle'])
+        df = df.drop(columns=['filename', 'filepath',
+                              'bundle_lid', 'bundle'])
 
     if args.sort_by:
         df.sort_values(by=args.sort_by, inplace=True)
@@ -297,7 +296,7 @@ def main():
 
         # Append file path and file name to the dictionary
         result_dict = {'LID': lid, 'Results': xml_results,
-                       'pds:filepath': filepath, 'pds:filename': file.name}
+                       'filepath': filepath, 'filename': file.name}
 
         all_results.append(result_dict)
 

--- a/indextools/pds4_create_xml_index.py
+++ b/indextools/pds4_create_xml_index.py
@@ -14,6 +14,7 @@ Usage:
         [--verbose]
         [--sort-by SORT_BY] 
         [--clean-header-field-names]
+        [--extra-file-info EXTRA_FILE_INFO]
 
 Arguments:
     directorypath        The path to the directory containing the bundle to scrape.
@@ -30,6 +31,10 @@ Arguments:
     --sort-by            Sort the index file by a chosen set of columns.
     --clean-header-field-names
                          Replace the ":" and "/" with Windows-friendly characters.
+    --extra-file-info    Add additional column(s) to the index file containing file or
+                         bundle information. Possible values are: "LID", "filename",
+                         "filepath", "bundle", and "bundle_lid". Multiple values may be
+                         specified separated by spaces. Surround each value with quotes.
 
 Example:
 python3 pds4_create_xml_index.py <toplevel_directory> "glob_path1" "glob_path2" 
@@ -166,40 +171,9 @@ def write_results_to_csv(results_list, args, output_csv_path):
     """
     rows = []
     for result_dict in results_list:
-        lid = result_dict['LID']
-        bundle_lid = ':'.join(lid.split(':')[:4])
-        bundle = bundle_lid.split(':')[-1]
-
-        row = {
-            'LID': lid,
-            'filepath': result_dict['filepath'],
-            'filename': result_dict['filename'],
-            'bundle_lid': bundle_lid,
-            'bundle': bundle
-        }
-        row.update(result_dict['Results'])
-        rows.append(row)
+        rows.append(result_dict['Results'])
 
     df = pd.DataFrame(rows)
-
-    columns_order = (['LID',
-                      'filename',
-                      'filepath',
-                      'bundle_lid',
-                      'bundle'] + [col for col in df.columns if col not in
-                                       ['LID',
-                                        'filename',
-                                        'filepath',
-                                        'bundle_lid',
-                                        'bundle']])
-
-    df = df[columns_order]
-
-    if 'LID' in df.columns:
-        df = df.drop(columns=['LID'])
-    if args.elements_file:
-        df = df.drop(columns=['filename', 'filepath',
-                              'bundle_lid', 'bundle'])
 
     if args.sort_by:
         df.sort_values(by=args.sort_by, inplace=True)
@@ -244,6 +218,11 @@ def main():
     parser.add_argument('--clean-header-field-names', action='store_true',
                         help='Replaces the ":" and "/" in the column headers with '
                              'alternative (legal friendly) characters')
+    parser.add_argument('--extra-file-info', type=str, nargs='+',
+                        help='Adds additional columns to the final index file. Choose '
+                             'from the following: "LID", "filename", "filepath", '
+                             '"bundle_lid", and "bundle". If using multiple, separate '
+                             'with spaces. Surround each value with quotes.')
 
     args = parser.parse_args()
 
@@ -294,10 +273,16 @@ def main():
 
         lid = xml_results.get('pds:logical_identifier', 'Missing_LID')
 
-        # Append file path and file name to the dictionary
-        result_dict = {'LID': lid, 'Results': xml_results,
-                       'filepath': filepath, 'filename': file.name}
-
+        # Attach extra columns if asked for.
+        bundle_lid = ':'.join(lid.split(':')[:4])
+        bundle = bundle_lid.split(':')[-1]
+        extras = {'LID': lid, 'filepath': filepath, 'filename': file.name,
+                  'bundle': bundle, 'bundle_lid': bundle_lid}
+        if args.extra_file_info:
+            xml_results = {**{ele: extras[ele] for ele in args.extra_file_info},
+                           **xml_results}
+            
+        result_dict = {'Results': xml_results}
         all_results.append(result_dict)
 
     if args.output_file:

--- a/indextools/pds4_create_xml_index.py
+++ b/indextools/pds4_create_xml_index.py
@@ -34,7 +34,7 @@ Arguments:
     --extra-file-info    Add additional column(s) to the index file containing file or
                          bundle information. Possible values are: "LID", "filename",
                          "filepath", "bundle", and "bundle_lid". Multiple values may be
-                         specified separated by spaces. Surround each value with quotes.
+                         specified separated by spaces.
 
 Example:
 python3 pds4_create_xml_index.py <toplevel_directory> "glob_path1" "glob_path2" 
@@ -218,11 +218,12 @@ def main():
     parser.add_argument('--clean-header-field-names', action='store_true',
                         help='Replaces the ":" and "/" in the column headers with '
                              'alternative (legal friendly) characters')
-    parser.add_argument('--extra-file-info', type=str, nargs='+',
+    parser.add_argument('--extra-file-info', type=str, nargs='+', 
+                        choices=['LID', 'filename', 'filepath', 'bundle_lid', 'bundle'],
                         help='Adds additional columns to the final index file. Choose '
                              'from the following: "LID", "filename", "filepath", '
                              '"bundle_lid", and "bundle". If using multiple, separate '
-                             'with spaces. Surround each value with quotes.')
+                             'with spaces.')
 
     args = parser.parse_args()
 


### PR DESCRIPTION
This pull will introduce a new command-line argument for `pds4_create_xml_index.py`: `--extra-file-info`.

When this command line argument is used, you may list any number of the following terms surrounded by quotes and separated by spaces:
```
filename
filepath
bundle
bundle_lid
```

The code now adds the requested columns in, placing them in the front of the final index file in the order which they are requested. This feature works with or without the use of `--elements-list`. 

Here is an example: 
```
python3 pds4_create_xml_index.py /Volumes/Emilie-Data/pds4-holdings/bundles/uranus_occs_earthbased/ "uranus_occ_u11_ctio_400cm/data/rings/*.xml"  --elements-file "sample_elements.txt" --output-file "/Users/emiliesimpson/Desktop/tester_index.csv" --extra-file-info "filename" "filepath"
```

Fixes #70 